### PR TITLE
Add Parquet support

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -10,13 +10,14 @@
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
     <PackageVersion Include="Octopus.CoreParsers.Hcl" Version="1.1.599" />
-    <PackageVersion Include="Shouldly" Version="4.2.1" />
+    <PackageVersion Include="Parquet.Net" Version="5.3.0" />
+    <PackageVersion Include="Shouldly" Version="4.3.0" />
     <PackageVersion Include="System.Interactive.Async" Version="7.0.0-preview.10" />
     <PackageVersion Include="System.Management.Automation" Version="7.5.4" />
     <PackageVersion Include="Tomlyn" Version="0.19.0" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageVersion Include="YamlDotNet" Version="16.3.0" />
-    <PackageVersion Include="Zio" Version="0.21.2" />
+    <PackageVersion Include="Zio" Version="0.21.3" />
   </ItemGroup>
 </Project>

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ ROFSDB provides a simple, efficient way to read and query data stored in files o
 ## Features
 
 - 🗂️ **Collection-based organization** - Directories represent collections, files represent documents
-- 📄 **Multiple format support** - JSON, YAML, TOML, HCL, and PowerShell Data files (PSD1)
+- 📄 **Multiple format support** - JSON, YAML, TOML, HCL, PowerShell Data files (PSD1), and Parquet
 - ⚡ **Async streaming** - Efficient `IAsyncEnumerable<T>` API for memory-efficient data access
 - 🔌 **Dependency Injection** - Built-in support for Microsoft.Extensions.DependencyInjection
 - 🔄 **Flexible storage** - Works with physical filesystems, embedded resources, or virtual filesystems (via Zio)
@@ -125,6 +125,7 @@ ROFSDB supports the following file formats:
 | **TOML** | `.toml` | Tom's Obvious, Minimal Language |
 | **HCL** | `.hcl` | HashiCorp Configuration Language |
 | **PowerShell Data** | `.psd1` | PowerShell Data files |
+| **Parquet** | `.parquet` | Apache Parquet columnar storage format |
 
 ### Format Examples
 
@@ -231,6 +232,7 @@ ROFSDB/
 │   ├── YamlSerialization.cs
 │   ├── TomlSerialization.cs
 │   ├── HclSerialization.cs
+│   ├── ParquetSerialization.cs
 │   └── PowerShellDataFileSerialization.cs
 └── ServiceCollectionExtensions.cs  # DI extension methods
 ```

--- a/src/ROFSDB.Tests/DatabaseEngineTests.cs
+++ b/src/ROFSDB.Tests/DatabaseEngineTests.cs
@@ -21,6 +21,7 @@ public class DatabaseEngineTests(ITestOutputHelper testOutputHelper, DatabaseEng
     [InlineData("HCL")]
     [InlineData("JSON")]
     [InlineData("PSD1")]
+    [InlineData("PARQUET")]
     public async Task CityCountTest(string fileFormat)
     {
         databaseEngineFixture.WriteFilesAndFoldersToTestOutput(fileFormat, testOutputHelper);
@@ -36,6 +37,7 @@ public class DatabaseEngineTests(ITestOutputHelper testOutputHelper, DatabaseEng
     [InlineData("HCL")]
     [InlineData("JSON")]
     [InlineData("PSD1")]
+    [InlineData("PARQUET")]
     public async Task CollectionNameTest(string fileFormat)
     {
         databaseEngineFixture.WriteFilesAndFoldersToTestOutput(fileFormat, testOutputHelper);
@@ -52,6 +54,7 @@ public class DatabaseEngineTests(ITestOutputHelper testOutputHelper, DatabaseEng
     [InlineData("HCL")]
     [InlineData("JSON")]
     [InlineData("PSD1")]
+    [InlineData("PARQUET")]
     public async Task CountryCityRelationsTest(string fileFormat)
     {
         databaseEngineFixture.WriteFilesAndFoldersToTestOutput(fileFormat, testOutputHelper);
@@ -70,6 +73,7 @@ public class DatabaseEngineTests(ITestOutputHelper testOutputHelper, DatabaseEng
     [InlineData("HCL")]
     [InlineData("JSON")]
     [InlineData("PSD1")]
+    [InlineData("PARQUET")]
     public async Task CountryCountTest(string fileFormat)
     {
         databaseEngineFixture.WriteFilesAndFoldersToTestOutput(fileFormat, testOutputHelper);
@@ -85,6 +89,7 @@ public class DatabaseEngineTests(ITestOutputHelper testOutputHelper, DatabaseEng
     [InlineData("HCL")]
     [InlineData("JSON")]
     [InlineData("PSD1")]
+    [InlineData("PARQUET")]
     public async Task CountryIdTest(string fileFormat)
     {
         databaseEngineFixture.WriteFilesAndFoldersToTestOutput(fileFormat, testOutputHelper);
@@ -105,6 +110,7 @@ public class DatabaseEngineTests(ITestOutputHelper testOutputHelper, DatabaseEng
     [InlineData("HCL")]
     [InlineData("JSON")]
     [InlineData("PSD1")]
+    [InlineData("PARQUET")]
     public async Task CountryNameTest(string fileFormat)
     {
         databaseEngineFixture.WriteFilesAndFoldersToTestOutput(fileFormat, testOutputHelper);

--- a/src/ROFSDB.Tests/Fixtures/DatabaseEngineFixture.cs
+++ b/src/ROFSDB.Tests/Fixtures/DatabaseEngineFixture.cs
@@ -1,9 +1,14 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
+using Parquet;
+using Parquet.Data;
+using Parquet.Schema;
 using System.Collections.Frozen;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using TIKSN.ROFSDB.FileStorageAdapters;
+using TIKSN.ROFSDB.Tests.Models;
 using Xunit;
 using Xunit.Abstractions;
 using Zio;
@@ -13,7 +18,7 @@ namespace TIKSN.ROFSDB.Tests.Fixtures;
 
 public class DatabaseEngineFixture : IAsyncLifetime
 {
-    private static readonly string[] SerializationFormats = ["YAML", "TOML", "HCL", "JSON", "PSD1"];
+    private static readonly string[] SerializationFormats = ["YAML", "TOML", "HCL", "JSON", "PSD1", "PARQUET"];
     private FrozenDictionary<string, ServiceProvider> formatServiceProviders;
     private MemoryFileSystem memoryFileSystem;
     public FrozenDictionary<string, IDatabaseEngine> DatabaseEngines { get; private set; }
@@ -27,7 +32,7 @@ public class DatabaseEngineFixture : IAsyncLifetime
     public async Task InitializeAsync()
     {
         this.memoryFileSystem = new();
-        WriteFiles(memoryFileSystem);
+        await WriteFiles(memoryFileSystem);
         this.formatServiceProviders = SerializationFormats.ToFrozenDictionary(
             keySelector: x => x,
             elementSelector: x =>
@@ -56,7 +61,7 @@ public class DatabaseEngineFixture : IAsyncLifetime
         }
     }
 
-    private static void WriteEuropeanCountries(IFileSystem fileSystem, StringBuilder stringBuilder)
+    private static async Task WriteEuropeanCountries(IFileSystem fileSystem, StringBuilder stringBuilder)
     {
         #region YAML
 
@@ -162,17 +167,27 @@ public class DatabaseEngineFixture : IAsyncLifetime
         fileSystem.WriteAllText("/PSD1/Countries/Europe-Italy.psd1", stringBuilder.ToString(), Encoding.UTF8);
 
         #endregion PSD1
+
+        #region PARQUET
+
+        await WriteParquetCountries(fileSystem, [
+            new Country { ID = 1419150635, Name = "Austria" },
+            new Country { ID = 1552721979, Name = "France" },
+            new Country { ID = 1501801186, Name = "Italy" }
+        ], "/PARQUET/Countries/Europe.parquet");
+
+        #endregion PARQUET
     }
 
-    private static void WriteFiles(IFileSystem fileSystem)
+    private static async Task WriteFiles(IFileSystem fileSystem)
     {
         WriteFolders(fileSystem);
 
         var stringBuilder = new StringBuilder();
-        WriteNorthAmericanCountries(fileSystem, stringBuilder);
-        WriteEuropeanCountries(fileSystem, stringBuilder);
-        WriteMegacities(fileSystem, stringBuilder);
-        WriteNonMegacities(fileSystem, stringBuilder);
+        await WriteNorthAmericanCountries(fileSystem, stringBuilder);
+        await WriteEuropeanCountries(fileSystem, stringBuilder);
+        await WriteMegacities(fileSystem, stringBuilder);
+        await WriteNonMegacities(fileSystem, stringBuilder);
     }
 
     private static void WriteFolders(IFileSystem fileSystem)
@@ -184,7 +199,7 @@ public class DatabaseEngineFixture : IAsyncLifetime
         }
     }
 
-    private static void WriteMegacities(IFileSystem fileSystem, StringBuilder stringBuilder)
+    private static async Task WriteMegacities(IFileSystem fileSystem, StringBuilder stringBuilder)
     {
         #region YAML
 
@@ -241,9 +256,17 @@ public class DatabaseEngineFixture : IAsyncLifetime
         fileSystem.WriteAllText("/PSD1/Cities/Megacities-NewYorkCity.psd1", stringBuilder.ToString(), Encoding.UTF8);
 
         #endregion PSD1
+
+        #region PARQUET
+
+        await WriteParquetCities(fileSystem, [
+            new City { ID = 918909193, Name = "New York City", CountryID = 1100746772 }
+        ], "/PARQUET/Cities/Megacities.parquet");
+
+        #endregion PARQUET
     }
 
-    private static void WriteNonMegacities(IFileSystem fileSystem, StringBuilder stringBuilder)
+    private static async Task WriteNonMegacities(IFileSystem fileSystem, StringBuilder stringBuilder)
     {
         #region YAML
 
@@ -428,9 +451,21 @@ public class DatabaseEngineFixture : IAsyncLifetime
         fileSystem.WriteAllText("/PSD1/Cities/Non-Megacities-Rome.psd1", stringBuilder.ToString(), Encoding.UTF8);
 
         #endregion PSD1
+
+        #region PARQUET
+
+        await WriteParquetCities(fileSystem, [
+            new City { ID = 356389956, Name = "Austin", CountryID = 1100746772 },
+            new City { ID = 1572248850, Name = "Toronto", CountryID = 965475701 },
+            new City { ID = 1859443008, Name = "Vienna", CountryID = 1419150635 },
+            new City { ID = 1948404451, Name = "Paris", CountryID = 1552721979 },
+            new City { ID = 1062005753, Name = "Rome", CountryID = 1501801186 }
+        ], "/PARQUET/Cities/Non-Megacities.parquet");
+
+        #endregion PARQUET
     }
 
-    private static void WriteNorthAmericanCountries(IFileSystem fileSystem, StringBuilder stringBuilder)
+    private static async Task WriteNorthAmericanCountries(IFileSystem fileSystem, StringBuilder stringBuilder)
     {
         #region YAML
 
@@ -509,5 +544,46 @@ public class DatabaseEngineFixture : IAsyncLifetime
         fileSystem.WriteAllText("/PSD1/Countries/NorthAmerica-Canada.psd1", stringBuilder.ToString(), Encoding.UTF8);
 
         #endregion PSD1
+
+        #region PARQUET
+
+        await WriteParquetCountries(fileSystem, [
+            new Country { ID = 1100746772, Name = "United States" },
+            new Country { ID = 965475701, Name = "Canada" }
+        ], "/PARQUET/Countries/NorthAmerica.parquet");
+
+        #endregion PARQUET
+    }
+
+    private static async Task WriteParquetCountries(IFileSystem fileSystem, Country[] countries, string filePath)
+    {
+        var schema = new ParquetSchema(
+            new DataField<int>("ID"),
+            new DataField<string>("Name")
+        );
+
+        await using var stream = fileSystem.OpenFile(filePath, FileMode.Create, FileAccess.Write);
+        await using var parquetWriter = await ParquetWriter.CreateAsync(schema, stream);
+
+        using var rowGroup = parquetWriter.CreateRowGroup();
+        await rowGroup.WriteColumnAsync(new DataColumn(schema.DataFields[0], countries.Select(c => c.ID).ToArray()));
+        await rowGroup.WriteColumnAsync(new DataColumn(schema.DataFields[1], countries.Select(c => c.Name).ToArray()));
+    }
+
+    private static async Task WriteParquetCities(IFileSystem fileSystem, City[] cities, string filePath)
+    {
+        var schema = new ParquetSchema(
+            new DataField<int>("ID"),
+            new DataField<string>("Name"),
+            new DataField<int>("CountryID")
+        );
+
+        await using var stream = fileSystem.OpenFile(filePath, FileMode.Create, FileAccess.Write);
+        await using var parquetWriter = await ParquetWriter.CreateAsync(schema, stream);
+
+        using var rowGroup = parquetWriter.CreateRowGroup();
+        await rowGroup.WriteColumnAsync(new DataColumn(schema.DataFields[0], cities.Select(c => c.ID).ToArray()));
+        await rowGroup.WriteColumnAsync(new DataColumn(schema.DataFields[1], cities.Select(c => c.Name).ToArray()));
+        await rowGroup.WriteColumnAsync(new DataColumn(schema.DataFields[2], cities.Select(c => c.CountryID).ToArray()));
     }
 }

--- a/src/ROFSDB.Tests/ROFSDB.Tests.csproj
+++ b/src/ROFSDB.Tests/ROFSDB.Tests.csproj
@@ -11,6 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Parquet.Net" />
     <PackageReference Include="Shouldly" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit" />

--- a/src/ROFSDB.Tests/Serialization/ParquetSerializationTests.cs
+++ b/src/ROFSDB.Tests/Serialization/ParquetSerializationTests.cs
@@ -1,0 +1,97 @@
+using Shouldly;
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using TIKSN.ROFSDB.Serialization;
+using TIKSN.ROFSDB.Tests.Fixtures;
+using TIKSN.ROFSDB.Tests.Models;
+using Xunit;
+
+namespace TIKSN.ROFSDB.Tests.Serialization;
+
+public class ParquetSerializationTests(DatabaseEngineFixture fixture) : IClassFixture<DatabaseEngineFixture>
+{
+    private readonly ParquetSerialization serialization = new();
+    private readonly DatabaseEngineFixture fixture = fixture;
+
+    [Fact]
+    public void FileExtensions_ShouldReturnParquetExtension()
+    {
+        var extensions = serialization.FileExtensions.ToArray();
+
+        extensions.ShouldContain(".parquet");
+        extensions.Length.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task GetDocumentsAsync_ShouldReadCountriesFromParquetFile()
+    {
+        var countries = await fixture.DatabaseEngines["PARQUET"]
+            .GetDocumentsAsync<Country>("Countries", CancellationToken.None)
+            .ToArrayAsync();
+
+        countries.Length.ShouldBe(5);
+        countries.Select(c => c.ID).ShouldContain(1100746772);
+        countries.Select(c => c.Name).ShouldContain("United States");
+    }
+
+    [Fact]
+    public async Task GetDocumentsAsync_ShouldReadCitiesFromParquetFile()
+    {
+        var cities = await fixture.DatabaseEngines["PARQUET"]
+            .GetDocumentsAsync<City>("Cities", CancellationToken.None)
+            .ToArrayAsync();
+
+        cities.Length.ShouldBe(6);
+        cities.ShouldContain(c => c.Name == "New York City");
+        cities.ShouldContain(c => c.Name == "Vienna");
+    }
+
+    [Fact]
+    public async Task GetDocumentsAsync_ShouldHandleBinaryStreamCorrectly()
+    {
+        var countries = await fixture.DatabaseEngines["PARQUET"]
+            .GetDocumentsAsync<Country>("Countries", CancellationToken.None)
+            .ToArrayAsync();
+
+        countries.Length.ShouldBeGreaterThan(0);
+
+        foreach (var country in countries)
+        {
+            country.ID.ShouldBeGreaterThan(0);
+            country.Name.ShouldNotBeNullOrEmpty();
+        }
+    }
+
+    [Fact]
+    public async Task GetDocumentsAsync_ShouldRespectCancellationToken()
+    {
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await Should.ThrowAsync<OperationCanceledException>(async () =>
+        {
+            await foreach (var _ in fixture.DatabaseEngines["PARQUET"]
+                .GetDocumentsAsync<Country>("Countries", cts.Token))
+            {
+                // Should be cancelled before reading
+            }
+        });
+    }
+
+    [Fact]
+    public async Task GetDocumentsAsync_ShouldHandleCaseInsensitivePropertyMatching()
+    {
+        var countries = await fixture.DatabaseEngines["PARQUET"]
+            .GetDocumentsAsync<Country>("Countries", CancellationToken.None)
+            .ToArrayAsync();
+
+        foreach (var country in countries)
+        {
+            country.ID.ShouldBeGreaterThan(0);
+            country.Name.ShouldNotBeNullOrEmpty();
+        }
+    }
+}
+

--- a/src/ROFSDB/ROFSDB.csproj
+++ b/src/ROFSDB/ROFSDB.csproj
@@ -21,6 +21,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Octopus.CoreParsers.Hcl" />
+    <PackageReference Include="Parquet.Net" />
     <PackageReference Include="System.Interactive.Async" />
     <PackageReference Include="System.Management.Automation" />
     <PackageReference Include="Tomlyn" />

--- a/src/ROFSDB/Serialization/ParquetSerialization.cs
+++ b/src/ROFSDB/Serialization/ParquetSerialization.cs
@@ -1,0 +1,110 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using Parquet;
+using Parquet.Data;
+
+namespace TIKSN.ROFSDB.Serialization;
+
+public class ParquetSerialization : ISerialization
+{
+    private static readonly IEnumerable<string> fileExtensions = [".parquet"];
+
+    public IEnumerable<string> FileExtensions => fileExtensions;
+
+    public async IAsyncEnumerable<T> GetDocumentsAsync<T>(
+        Stream stream,
+        [EnumeratorCancellation] CancellationToken cancellationToken)
+        where T : class, new()
+    {
+        using var parquetReader = await ParquetReader.CreateAsync(stream, cancellationToken: cancellationToken);
+        var schema = parquetReader.Schema;
+        var dataFields = schema.GetDataFields();
+
+        var rowGroupCount = parquetReader.RowGroupCount;
+        for (int rowGroupIndex = 0; rowGroupIndex < rowGroupCount; rowGroupIndex++)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            using var rowGroupReader = parquetReader.OpenRowGroupReader(rowGroupIndex);
+            var rowCountInGroup = rowGroupReader.RowCount;
+
+            var columns = new Dictionary<string, DataColumn>();
+            foreach (var field in dataFields)
+            {
+                var column = await rowGroupReader.ReadColumnAsync(field, cancellationToken);
+                columns[field.Name] = column;
+            }
+
+            for (int rowIndex = 0; rowIndex < rowCountInGroup; rowIndex++)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                var instance = new T();
+                var type = typeof(T);
+
+                foreach (var field in dataFields)
+                {
+                    var property = type.GetProperty(field.Name, BindingFlags.IgnoreCase | BindingFlags.Public | BindingFlags.Instance);
+                    if (property != null && property.CanWrite)
+                    {
+                        var column = columns[field.Name];
+                        var value = GetValueFromDataColumn(column, rowIndex, property.PropertyType);
+                        if (value != null)
+                        {
+                            property.SetValue(instance, value);
+                        }
+                    }
+                }
+
+                yield return instance;
+            }
+        }
+    }
+
+    private static object GetValueFromDataColumn(DataColumn column, int rowIndex, Type targetType)
+    {
+        if (rowIndex >= column.Data.Length)
+        {
+            return null;
+        }
+
+        var value = column.Data.GetValue(rowIndex);
+        if (value == null)
+        {
+            return null;
+        }
+
+        if (targetType.IsAssignableFrom(value.GetType()))
+        {
+            return value;
+        }
+
+        if (targetType == typeof(string))
+        {
+            return value.ToString();
+        }
+
+        var underlyingType = Nullable.GetUnderlyingType(targetType);
+        if (underlyingType != null)
+        {
+            if (value == null || value is DBNull)
+            {
+                return null;
+            }
+            return Convert.ChangeType(value, underlyingType);
+        }
+
+        try
+        {
+            return Convert.ChangeType(value, targetType);
+        }
+        catch
+        {
+            return value;
+        }
+    }
+}

--- a/src/ROFSDB/ServiceCollectionExtensions.cs
+++ b/src/ROFSDB/ServiceCollectionExtensions.cs
@@ -19,6 +19,7 @@ public static class ServiceCollectionExtensions
 
         services.TryAddKeyedSingleton<ISerialization, HclSerialization>("HCL");
         services.TryAddKeyedSingleton<ISerialization, JsonSerialization>("JSON");
+        services.TryAddKeyedSingleton<ISerialization, ParquetSerialization>("PARQUET");
         services.TryAddKeyedSingleton<ISerialization, TomlSerialization>("TOML");
         services.TryAddKeyedSingleton<ISerialization, YamlSerialization>("YAML");
         services.TryAddKeyedSingleton<ISerialization, PowerShellDataFileSerialization>("PSD1");


### PR DESCRIPTION
- Introduced Parquet serialization with a new ParquetSerialization class.
- Updated Directory.Packages.props and project files to include Parquet.Net package.
- Enhanced README.md to document Parquet format support.
- Updated DatabaseEngine tests and fixture to include Parquet format handling.
- Added tests for Parquet serialization to ensure functionality and data integrity.

Closes #116 