### PR TITLE
Add KDL support with KdlSharp and document the new format

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,6 +5,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="coverlet.collector" Version="6.0.4" />
+    <PackageVersion Include="KdlSharp" Version="1.1.0" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
     <PackageVersion Include="Microsoft.Extensions.FileProviders.Abstractions" Version="10.0.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ ROFSDB provides a simple, efficient way to read and query data stored in files o
 ## Features
 
 - 🗂️ **Collection-based organization** - Directories represent collections, files represent documents
-- 📄 **Multiple format support** - JSON, YAML, TOML, HCL, PowerShell Data files (PSD1), and Parquet
+- 📄 **Multiple format support** - JSON, YAML, TOML, KDL, HCL, PowerShell Data files (PSD1), and Parquet
 - ⚡ **Async streaming** - Efficient `IAsyncEnumerable<T>` API for memory-efficient data access
 - 🔌 **Dependency Injection** - Built-in support for Microsoft.Extensions.DependencyInjection
 - 🔄 **Flexible storage** - Works with physical filesystems, embedded resources, or virtual filesystems (via Zio)
@@ -63,10 +63,12 @@ data/
 ├── Cities/
 │   ├── city1.json
 │   ├── city2.yaml
-│   └── city3.toml
+│   ├── city3.toml
+│   └── city4.kdl
 └── Countries/
     ├── country1.json
-    └── country2.yaml
+    ├── country2.yaml
+    └── country3.kdl
 ```
 
 ### 3. Configure Services
@@ -141,6 +143,7 @@ ROFSDB supports the following file formats:
 | **JSON** | `.json` | JavaScript Object Notation |
 | **YAML** | `.yaml`, `.yml` | YAML Ain't Markup Language |
 | **TOML** | `.toml` | Tom's Obvious, Minimal Language |
+| **KDL** | `.kdl` | KDL Document Language |
 | **HCL** | `.hcl` | HashiCorp Configuration Language |
 | **PowerShell Data** | `.psd1` | PowerShell Data files |
 | **Parquet** | `.parquet` | Apache Parquet columnar storage format |
@@ -170,7 +173,41 @@ population = 8336817
 countryID = 1100746772
 ```
 
-Files can contain either a single document or an array of documents. Arrays are automatically expanded into individual documents.
+**KDL** (`city.kdl`):
+```kdl
+city name="New York" population=8336817 country-id=1100746772
+```
+
+KDL files target KDL v2 and use top-level nodes named after the target C# model type in acronym-aware kebab case:
+
+- `Country` maps to `country`
+- `City` maps to `city`
+- `IPAddressRule` maps to `ip-address-rule`
+- `ID` maps to `id`
+- `CountryID` maps to `country-id`
+
+KDL members can be written as node properties or as scalar child nodes with one argument:
+
+```kdl
+country id=1419150635 name="Austria"
+
+country {
+  id 1552721979
+  name "France"
+}
+```
+
+One `.kdl` file can contain multiple documents of the same type:
+
+```kdl
+country id=1419150635 name="Austria"
+country id=1552721979 name="France"
+country id=1501801186 name="Italy"
+```
+
+KDL support is strict: node and member names are case-sensitive, unknown members throw, unexpected top-level node names throw, and duplicate members throw. Missing members keep their normal CLR default values. The initial KDL mapper supports flat POCOs with public writable scalar properties. KDL v2 scalar literals such as `#true`, `#false`, and `#null` are supported.
+
+Files in most text formats can contain either a single document or multiple documents, depending on the format. JSON arrays, YAML multi-document streams, and KDL repeated top-level nodes are automatically expanded into individual documents.
 
 ## Advanced Usage
 
@@ -249,6 +286,7 @@ ROFSDB/
 │   └── ZioFileSystemToFileStorageAdapter.cs
 ├── Serialization/              # Serialization format implementations
 │   ├── JsonSerialization.cs
+│   ├── KdlSerialization.cs
 │   ├── YamlSerialization.cs
 │   ├── TomlSerialization.cs
 │   ├── HclSerialization.cs
@@ -269,3 +307,5 @@ Contributions are welcome! Please feel free to submit a Pull Request.
 
 - [NuGet Package](https://www.nuget.org/packages/ROFSDB)
 - [GitHub Repository](https://github.com/tiksn/ROFSDB)
+- [KDL](https://kdl.dev/)
+- [KdlSharp](https://github.com/AndreyAkinshin/KdlSharp)

--- a/src/ROFSDB.Tests/DatabaseContextTests.cs
+++ b/src/ROFSDB.Tests/DatabaseContextTests.cs
@@ -22,6 +22,7 @@ public class DatabaseContextTests(ITestOutputHelper testOutputHelper, DatabaseCo
     [InlineData("JSON")]
     [InlineData("PSD1")]
     [InlineData("PARQUET")]
+    [InlineData("KDL")]
     public async Task CityCountTest(string fileFormat)
     {
         databaseContextFixture.WriteFilesAndFoldersToTestOutput(fileFormat, testOutputHelper);
@@ -38,6 +39,7 @@ public class DatabaseContextTests(ITestOutputHelper testOutputHelper, DatabaseCo
     [InlineData("JSON")]
     [InlineData("PSD1")]
     [InlineData("PARQUET")]
+    [InlineData("KDL")]
     public async Task CountryCityRelationsTest(string fileFormat)
     {
         databaseContextFixture.WriteFilesAndFoldersToTestOutput(fileFormat, testOutputHelper);
@@ -57,6 +59,7 @@ public class DatabaseContextTests(ITestOutputHelper testOutputHelper, DatabaseCo
     [InlineData("JSON")]
     [InlineData("PSD1")]
     [InlineData("PARQUET")]
+    [InlineData("KDL")]
     public async Task CountryCountTest(string fileFormat)
     {
         databaseContextFixture.WriteFilesAndFoldersToTestOutput(fileFormat, testOutputHelper);
@@ -73,6 +76,7 @@ public class DatabaseContextTests(ITestOutputHelper testOutputHelper, DatabaseCo
     [InlineData("JSON")]
     [InlineData("PSD1")]
     [InlineData("PARQUET")]
+    [InlineData("KDL")]
     public async Task CountryIdTest(string fileFormat)
     {
         databaseContextFixture.WriteFilesAndFoldersToTestOutput(fileFormat, testOutputHelper);
@@ -94,6 +98,7 @@ public class DatabaseContextTests(ITestOutputHelper testOutputHelper, DatabaseCo
     [InlineData("JSON")]
     [InlineData("PSD1")]
     [InlineData("PARQUET")]
+    [InlineData("KDL")]
     public async Task CountryNameTest(string fileFormat)
     {
         databaseContextFixture.WriteFilesAndFoldersToTestOutput(fileFormat, testOutputHelper);

--- a/src/ROFSDB.Tests/Fixtures/DatabaseContextFixture.cs
+++ b/src/ROFSDB.Tests/Fixtures/DatabaseContextFixture.cs
@@ -18,7 +18,7 @@ namespace TIKSN.ROFSDB.Tests.Fixtures;
 
 public class DatabaseContextFixture : IAsyncLifetime
 {
-    private static readonly string[] SerializationFormats = ["YAML", "TOML", "HCL", "JSON", "PSD1", "PARQUET"];
+    private static readonly string[] SerializationFormats = ["YAML", "TOML", "HCL", "JSON", "PSD1", "PARQUET", "KDL"];
     private FrozenDictionary<string, ServiceProvider> formatServiceProviders;
     private MemoryFileSystem memoryFileSystem;
     public FrozenDictionary<string, IDatabaseContext> DatabaseContexts { get; private set; }
@@ -169,6 +169,25 @@ public class DatabaseContextFixture : IAsyncLifetime
 
         #endregion PSD1
 
+        #region KDL
+
+        stringBuilder.Clear();
+        stringBuilder.AppendLine("country {");
+        stringBuilder.AppendLine("  id 1419150635");
+        stringBuilder.AppendLine("  name \"Austria\"");
+        stringBuilder.AppendLine("}");
+        stringBuilder.AppendLine("country {");
+        stringBuilder.AppendLine("  id 1552721979");
+        stringBuilder.AppendLine("  name \"France\"");
+        stringBuilder.AppendLine("}");
+        stringBuilder.AppendLine("country {");
+        stringBuilder.AppendLine("  id 1501801186");
+        stringBuilder.AppendLine("  name \"Italy\"");
+        stringBuilder.AppendLine("}");
+        fileSystem.WriteAllText("/KDL/Countries/Europe.kdl", stringBuilder.ToString(), Encoding.UTF8);
+
+        #endregion KDL
+
         #region PARQUET
 
         await WriteParquetCountries(fileSystem, [
@@ -257,6 +276,14 @@ public class DatabaseContextFixture : IAsyncLifetime
         fileSystem.WriteAllText("/PSD1/Cities/Megacities-NewYorkCity.psd1", stringBuilder.ToString(), Encoding.UTF8);
 
         #endregion PSD1
+
+        #region KDL
+
+        stringBuilder.Clear();
+        stringBuilder.AppendLine("city id=918909193 name=\"New York City\" country-id=1100746772");
+        fileSystem.WriteAllText("/KDL/Cities/Megacities.kdl", stringBuilder.ToString(), Encoding.UTF8);
+
+        #endregion KDL
 
         #region PARQUET
 
@@ -453,6 +480,18 @@ public class DatabaseContextFixture : IAsyncLifetime
 
         #endregion PSD1
 
+        #region KDL
+
+        stringBuilder.Clear();
+        stringBuilder.AppendLine("city id=356389956 name=\"Austin\" country-id=1100746772");
+        stringBuilder.AppendLine("city id=1572248850 name=\"Toronto\" country-id=965475701");
+        stringBuilder.AppendLine("city id=1859443008 name=\"Vienna\" country-id=1419150635");
+        stringBuilder.AppendLine("city id=1948404451 name=\"Paris\" country-id=1552721979");
+        stringBuilder.AppendLine("city id=1062005753 name=\"Rome\" country-id=1501801186");
+        fileSystem.WriteAllText("/KDL/Cities/Non-Megacities.kdl", stringBuilder.ToString(), Encoding.UTF8);
+
+        #endregion KDL
+
         #region PARQUET
 
         await WriteParquetCities(fileSystem, [
@@ -545,6 +584,15 @@ public class DatabaseContextFixture : IAsyncLifetime
         fileSystem.WriteAllText("/PSD1/Countries/NorthAmerica-Canada.psd1", stringBuilder.ToString(), Encoding.UTF8);
 
         #endregion PSD1
+
+        #region KDL
+
+        stringBuilder.Clear();
+        stringBuilder.AppendLine("country id=1100746772 name=\"United States\"");
+        stringBuilder.AppendLine("country id=965475701 name=\"Canada\"");
+        fileSystem.WriteAllText("/KDL/Countries/NorthAmerica.kdl", stringBuilder.ToString(), Encoding.UTF8);
+
+        #endregion KDL
 
         #region PARQUET
 

--- a/src/ROFSDB.Tests/Serialization/KdlSerializationTests.cs
+++ b/src/ROFSDB.Tests/Serialization/KdlSerializationTests.cs
@@ -1,0 +1,159 @@
+using Shouldly;
+using System;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using TIKSN.ROFSDB.Serialization;
+using TIKSN.ROFSDB.Tests.Fixtures;
+using TIKSN.ROFSDB.Tests.Models;
+using Xunit;
+
+namespace TIKSN.ROFSDB.Tests.Serialization;
+
+[Collection("Database Context collection")]
+public class KdlSerializationTests(DatabaseContextFixture fixture) : IClassFixture<DatabaseContextFixture>
+{
+    private readonly DatabaseContextFixture fixture = fixture;
+    private readonly KdlSerialization serialization = new();
+
+    [Fact]
+    public void FileExtensions_ShouldReturnKdlExtension()
+    {
+        var extensions = serialization.FileExtensions.ToArray();
+
+        extensions.ShouldContain(".kdl");
+        extensions.Length.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task GetDocumentsAsync_ShouldReadCountriesFromKdlFile()
+    {
+        var countries = await fixture.DatabaseContexts["KDL"]
+            .GetCountriesAsync(CancellationToken.None)
+            .ToArrayAsync();
+
+        countries.Length.ShouldBe(5);
+        countries.Select(c => c.ID).ShouldContain(1100746772);
+        countries.Select(c => c.Name).ShouldContain("United States");
+    }
+
+    [Fact]
+    public async Task GetDocumentsAsync_ShouldReadCitiesFromKdlFile()
+    {
+        var cities = await fixture.DatabaseContexts["KDL"]
+            .GetCitiesAsync(CancellationToken.None)
+            .ToArrayAsync();
+
+        cities.Length.ShouldBe(6);
+        cities.ShouldContain(c => c.Name == "New York City");
+        cities.ShouldContain(c => c.Name == "Vienna");
+    }
+
+    [Fact]
+    public async Task GetDocumentsAsync_ShouldReadMultipleNodesFromOneFile()
+    {
+        var countries = await ReadCountriesAsync("""
+            country id=1 name="Austria"
+            country id=2 name="Canada"
+            """);
+
+        countries.Select(x => x.Name).ShouldBe(["Austria", "Canada"]);
+    }
+
+    [Fact]
+    public async Task GetDocumentsAsync_ShouldReadInlineProperties()
+    {
+        var countries = await ReadCountriesAsync("country id=1419150635 name=\"Austria\"");
+
+        countries.Single().ID.ShouldBe(1419150635);
+        countries.Single().Name.ShouldBe("Austria");
+    }
+
+    [Fact]
+    public async Task GetDocumentsAsync_ShouldReadChildScalarNodes()
+    {
+        var countries = await ReadCountriesAsync("""
+            country {
+              id 1419150635
+              name "Austria"
+            }
+            """);
+
+        countries.Single().ID.ShouldBe(1419150635);
+        countries.Single().Name.ShouldBe("Austria");
+    }
+
+    [Fact]
+    public async Task GetDocumentsAsync_ShouldThrowForTypeNodeMismatch()
+    {
+        await Should.ThrowAsync<FormatException>(async () =>
+        {
+            _ = await ReadCountriesAsync("city id=1 name=\"Austin\" country-id=2");
+        });
+    }
+
+    [Fact]
+    public async Task GetDocumentsAsync_ShouldThrowForUnknownMember()
+    {
+        await Should.ThrowAsync<FormatException>(async () =>
+        {
+            _ = await ReadCountriesAsync("country id=1 name=\"Austria\" unknown=\"value\"");
+        });
+    }
+
+    [Fact]
+    public async Task GetDocumentsAsync_ShouldThrowForDuplicateMember()
+    {
+        await Should.ThrowAsync<FormatException>(async () =>
+        {
+            _ = await ReadCountriesAsync("""
+                country id=1 {
+                  id 2
+                  name "Austria"
+                }
+                """);
+        });
+    }
+
+    [Fact]
+    public async Task GetDocumentsAsync_ShouldMatchMembersCaseSensitively()
+    {
+        await Should.ThrowAsync<FormatException>(async () =>
+        {
+            _ = await ReadCountriesAsync("country ID=1 name=\"Austria\"");
+        });
+    }
+
+    [Fact]
+    public async Task GetDocumentsAsync_ShouldUseDefaultsForMissingMembers()
+    {
+        var countries = await ReadCountriesAsync("country id=1419150635");
+
+        countries.Single().ID.ShouldBe(1419150635);
+        countries.Single().Name.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task GetDocumentsAsync_ShouldRespectCancellationToken()
+    {
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await Should.ThrowAsync<OperationCanceledException>(async () =>
+        {
+            _ = await ReadCountriesAsync("country id=1419150635 name=\"Austria\"", cts.Token);
+        });
+    }
+
+    private async Task<Country[]> ReadCountriesAsync(
+        string content,
+        CancellationToken cancellationToken = default)
+    {
+        await using var stream = new MemoryStream(Encoding.UTF8.GetBytes(content));
+        return await serialization
+            .GetDocumentsAsync<Country>(stream, cancellationToken)
+            .ToArrayAsync(cancellationToken);
+    }
+}

--- a/src/ROFSDB/ROFSDB.csproj
+++ b/src/ROFSDB/ROFSDB.csproj
@@ -14,6 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="KdlSharp" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
     <PackageReference Include="Microsoft.Extensions.FileProviders.Abstractions" />
     <PackageReference Include="Microsoft.SourceLink.GitHub">

--- a/src/ROFSDB/Serialization/KdlSerialization.cs
+++ b/src/ROFSDB/Serialization/KdlSerialization.cs
@@ -1,0 +1,361 @@
+using KdlSharp;
+using KdlSharp.Exceptions;
+using KdlSharp.Settings;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Threading;
+
+namespace TIKSN.ROFSDB.Serialization;
+
+public class KdlSerialization : ISerialization
+{
+    private static readonly IEnumerable<string> fileExtensions = [".kdl"];
+    private static readonly KdlParserSettings parserSettings = new()
+    {
+        TargetVersion = KdlVersion.V2,
+        AllowDuplicateProperties = false
+    };
+
+    public IEnumerable<string> FileExtensions => fileExtensions;
+
+    public async IAsyncEnumerable<T> GetDocumentsAsync<T>(
+        Stream stream,
+        [EnumeratorCancellation] CancellationToken cancellationToken)
+        where T : class, new()
+    {
+        KdlDocument document;
+        try
+        {
+            document = await KdlDocument.ParseStreamAsync(stream, parserSettings, leaveOpen: true, cancellationToken);
+        }
+        catch (KdlException ex)
+        {
+            throw new FormatException("Could not parse as KDL.", ex);
+        }
+
+        var expectedNodeName = ToKebabCase(typeof(T).Name);
+        var properties = GetSerializableProperties<T>();
+
+        foreach (var node in document.Nodes)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (!string.Equals(node.Name, expectedNodeName, StringComparison.Ordinal))
+            {
+                throw new FormatException(
+                    $"Unexpected KDL node '{node.Name}'. Expected '{expectedNodeName}' for '{typeof(T).Name}'.");
+            }
+
+            yield return DeserializeNode<T>(node, properties);
+        }
+    }
+
+    private static object ConvertValue(KdlValue value, Type targetType, string memberName)
+    {
+        var nullableType = Nullable.GetUnderlyingType(targetType);
+        if (value.ValueType == KdlValueType.Null)
+        {
+            if (!targetType.IsValueType || nullableType != null)
+            {
+                return null;
+            }
+
+            throw new FormatException($"KDL member '{memberName}' cannot be null.");
+        }
+
+        var conversionType = nullableType ?? targetType;
+
+        if (conversionType == typeof(string))
+        {
+            return RequireValue(value.ValueType == KdlValueType.String, value.AsString(), memberName, conversionType);
+        }
+
+        if (conversionType == typeof(char))
+        {
+            var text = RequireValue(value.ValueType == KdlValueType.String, value.AsString(), memberName, conversionType);
+            if (text.Length == 1)
+            {
+                return text[0];
+            }
+
+            throw new FormatException($"KDL member '{memberName}' must contain a single character.");
+        }
+
+        if (conversionType == typeof(bool))
+        {
+            return RequireBoolean(value, memberName, conversionType);
+        }
+
+        if (conversionType.IsEnum)
+        {
+            return ConvertEnumValue(value, conversionType, memberName);
+        }
+
+        if (IsIntegralType(conversionType))
+        {
+            var number = RequireNumber(value, memberName, conversionType);
+            return ConvertIntegralValue(number, conversionType, memberName);
+        }
+
+        if (conversionType == typeof(decimal))
+        {
+            return RequireNumber(value, memberName, conversionType);
+        }
+
+        if (conversionType == typeof(double))
+        {
+            return RequireDouble(value, memberName, conversionType);
+        }
+
+        if (conversionType == typeof(float))
+        {
+            var number = RequireDouble(value, memberName, conversionType);
+            return (float)number;
+        }
+
+        if (conversionType == typeof(Guid))
+        {
+            var text = RequireValue(value.ValueType == KdlValueType.String, value.AsString(), memberName, conversionType);
+            return Guid.Parse(text);
+        }
+
+        if (conversionType == typeof(DateTime))
+        {
+            var text = RequireValue(value.ValueType == KdlValueType.String, value.AsString(), memberName, conversionType);
+            return DateTime.Parse(text, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind);
+        }
+
+        if (conversionType == typeof(DateTimeOffset))
+        {
+            var text = RequireValue(value.ValueType == KdlValueType.String, value.AsString(), memberName, conversionType);
+            return DateTimeOffset.Parse(text, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind);
+        }
+
+        if (conversionType == typeof(TimeSpan))
+        {
+            var text = RequireValue(value.ValueType == KdlValueType.String, value.AsString(), memberName, conversionType);
+            return TimeSpan.Parse(text, CultureInfo.InvariantCulture);
+        }
+
+        throw new FormatException($"KDL member '{memberName}' has unsupported target type '{targetType.Name}'.");
+    }
+
+    private static object ConvertEnumValue(KdlValue value, Type enumType, string memberName)
+    {
+        if (value.ValueType == KdlValueType.String)
+        {
+            var text = RequireValue(true, value.AsString(), memberName, enumType);
+            return Enum.Parse(enumType, text, ignoreCase: false);
+        }
+
+        if (value.ValueType == KdlValueType.Number)
+        {
+            var number = RequireNumber(value, memberName, enumType);
+            var enumBaseType = Enum.GetUnderlyingType(enumType);
+            return Enum.ToObject(enumType, ConvertIntegralValue(number, enumBaseType, memberName));
+        }
+
+        throw new FormatException($"KDL member '{memberName}' cannot be converted to enum type '{enumType.Name}'.");
+    }
+
+    private static object ConvertIntegralValue(decimal number, Type targetType, string memberName)
+    {
+        if (decimal.Truncate(number) != number)
+        {
+            throw new FormatException($"KDL member '{memberName}' must be an integer.");
+        }
+
+        try
+        {
+            return Convert.ChangeType(number, targetType, CultureInfo.InvariantCulture);
+        }
+        catch (Exception ex) when (ex is InvalidCastException or OverflowException)
+        {
+            throw new FormatException($"KDL member '{memberName}' cannot be converted to '{targetType.Name}'.", ex);
+        }
+    }
+
+    private static T DeserializeNode<T>(KdlNode node, IReadOnlyDictionary<string, PropertyInfo> properties)
+        where T : class, new()
+    {
+        if (node.Arguments.Count != 0)
+        {
+            throw new FormatException($"KDL node '{node.Name}' must not contain positional arguments.");
+        }
+
+        T model = new();
+        var seenMembers = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var property in node.Properties)
+        {
+            SetMember(model, properties, seenMembers, property.Key, property.Value);
+        }
+
+        foreach (var child in node.Children)
+        {
+            if (child.Arguments.Count != 1 || child.Properties.Count != 0 || child.Children.Count != 0)
+            {
+                throw new FormatException(
+                    $"KDL child member '{child.Name}' must contain exactly one argument and no properties or children.");
+            }
+
+            SetMember(model, properties, seenMembers, child.Name, child.Arguments[0]);
+        }
+
+        return model;
+    }
+
+    private static IReadOnlyDictionary<string, PropertyInfo> GetSerializableProperties<T>()
+    {
+        var properties = typeof(T)
+            .GetProperties(BindingFlags.Instance | BindingFlags.Public)
+            .Where(static property => property.CanWrite && property.SetMethod?.IsPublic == true)
+            .ToArray();
+
+        var result = new Dictionary<string, PropertyInfo>(StringComparer.Ordinal);
+        foreach (var property in properties)
+        {
+            if (!IsSupportedType(property.PropertyType))
+            {
+                throw new FormatException(
+                    $"KDL member '{property.Name}' has unsupported target type '{property.PropertyType.Name}'.");
+            }
+
+            var memberName = ToKebabCase(property.Name);
+            if (!result.TryAdd(memberName, property))
+            {
+                throw new FormatException($"KDL member name '{memberName}' maps to more than one property.");
+            }
+        }
+
+        return result;
+    }
+
+    private static bool IsIntegralType(Type type)
+    {
+        type = Nullable.GetUnderlyingType(type) ?? type;
+
+        return type == typeof(byte) ||
+            type == typeof(sbyte) ||
+            type == typeof(short) ||
+            type == typeof(ushort) ||
+            type == typeof(int) ||
+            type == typeof(uint) ||
+            type == typeof(long) ||
+            type == typeof(ulong);
+    }
+
+    private static bool IsSupportedType(Type type)
+    {
+        type = Nullable.GetUnderlyingType(type) ?? type;
+
+        return type == typeof(string) ||
+            type == typeof(char) ||
+            type == typeof(bool) ||
+            type == typeof(decimal) ||
+            type == typeof(double) ||
+            type == typeof(float) ||
+            type == typeof(Guid) ||
+            type == typeof(DateTime) ||
+            type == typeof(DateTimeOffset) ||
+            type == typeof(TimeSpan) ||
+            type.IsEnum ||
+            IsIntegralType(type);
+    }
+
+    private static bool RequireBoolean(KdlValue value, string memberName, Type targetType)
+    {
+        var boolean = value.AsBoolean();
+        if (value.ValueType == KdlValueType.Boolean && boolean.HasValue)
+        {
+            return boolean.Value;
+        }
+
+        throw new FormatException($"KDL member '{memberName}' cannot be converted to '{targetType.Name}'.");
+    }
+
+    private static double RequireDouble(KdlValue value, string memberName, Type targetType)
+    {
+        var number = value.AsDouble();
+        if (value.ValueType == KdlValueType.Number && number.HasValue)
+        {
+            return number.Value;
+        }
+
+        throw new FormatException($"KDL member '{memberName}' cannot be converted to '{targetType.Name}'.");
+    }
+
+    private static decimal RequireNumber(KdlValue value, string memberName, Type targetType)
+    {
+        var number = value.AsNumber();
+        if (value.ValueType == KdlValueType.Number && number.HasValue)
+        {
+            return number.Value;
+        }
+
+        throw new FormatException($"KDL member '{memberName}' cannot be converted to '{targetType.Name}'.");
+    }
+
+    private static T RequireValue<T>(bool isExpectedValueType, T value, string memberName, Type targetType)
+    {
+        if (isExpectedValueType && value != null)
+        {
+            return value;
+        }
+
+        throw new FormatException($"KDL member '{memberName}' cannot be converted to '{targetType.Name}'.");
+    }
+
+    private static void SetMember<T>(
+        T model,
+        IReadOnlyDictionary<string, PropertyInfo> properties,
+        ISet<string> seenMembers,
+        string memberName,
+        KdlValue value)
+        where T : class, new()
+    {
+        if (!properties.TryGetValue(memberName, out var property))
+        {
+            throw new FormatException($"Unknown KDL member '{memberName}' for '{typeof(T).Name}'.");
+        }
+
+        if (!seenMembers.Add(memberName))
+        {
+            throw new FormatException($"Duplicate KDL member '{memberName}' for '{typeof(T).Name}'.");
+        }
+
+        property.SetValue(model, ConvertValue(value, property.PropertyType, memberName));
+    }
+
+    private static string ToKebabCase(string value)
+    {
+        if (string.IsNullOrEmpty(value))
+        {
+            return value;
+        }
+
+        var result = new List<char>(value.Length + 8);
+
+        for (var i = 0; i < value.Length; i++)
+        {
+            var current = value[i];
+            if (i > 0 &&
+                char.IsUpper(current) &&
+                (char.IsLower(value[i - 1]) ||
+                char.IsDigit(value[i - 1]) ||
+                (i + 1 < value.Length && char.IsUpper(value[i - 1]) && char.IsLower(value[i + 1]))))
+            {
+                result.Add('-');
+            }
+
+            result.Add(char.ToLowerInvariant(current));
+        }
+
+        return new string([.. result]);
+    }
+}

--- a/src/ROFSDB/ServiceCollectionExtensions.cs
+++ b/src/ROFSDB/ServiceCollectionExtensions.cs
@@ -19,6 +19,7 @@ public static class ServiceCollectionExtensions
 
         services.TryAddKeyedSingleton<ISerialization, HclSerialization>("HCL");
         services.TryAddKeyedSingleton<ISerialization, JsonSerialization>("JSON");
+        services.TryAddKeyedSingleton<ISerialization, KdlSerialization>("KDL");
         services.TryAddKeyedSingleton<ISerialization, ParquetSerialization>("PARQUET");
         services.TryAddKeyedSingleton<ISerialization, TomlSerialization>("TOML");
         services.TryAddKeyedSingleton<ISerialization, YamlSerialization>("YAML");


### PR DESCRIPTION
## Summary
- Added `.kdl` support via `KdlSharp` `1.1.0` and registered it by default in `AddROFSDB()`.
- Implemented a strict KDL serializer for flat POCOs with acronym-aware kebab-case type/member mapping, support for inline properties and scalar child nodes, and validation for unknown, duplicate, and mismatched nodes.
- Expanded the shared test fixtures and database context coverage to include KDL, and added focused serializer tests for the new format contract.
- Updated `README.md` with KDL examples, supported format details, and links to KDL/KdlSharp.

## Testing
- `dotnet test src\ROFSDB.slnx` passed.
- Added unit/integration coverage for KDL registration, document loading, validation failures, and cancellation behavior.